### PR TITLE
Add theming support

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,25 @@ To create a new table, use the `Editable()` widget class and provide the table d
         )
         ```
   - `createButtonLabel`:  Label for the create new row button
+
+### EditableTheme
+
+Default styles can be supplied using `EditableThemeData`. Add the theme to
+`ThemeData.extensions` or wrap a subtree with `EditableTheme`:
+
+```dart
+MaterialApp(
+  theme: ThemeData(
+    extensions: const [
+      EditableThemeData(borderColor: Colors.blueGrey),
+    ],
+  ),
+  home: MyHomePage(),
+);
+```
+
+Unset parameters on widgets will fall back to values from the nearest
+`EditableTheme`.
  
 ### Save methods
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -13,8 +13,28 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
         primaryColor: Colors.blue,
-
         visualDensity: VisualDensity.adaptivePlatformDensity,
+        extensions: const <ThemeExtension<dynamic>>[
+          EditableThemeData(
+            borderColor: Colors.blueGrey,
+            tdStyle: TextStyle(fontWeight: FontWeight.bold),
+            trHeight: 80,
+            thStyle: TextStyle(fontSize: 15, fontWeight: FontWeight.bold),
+            thAlignment: TextAlign.center,
+            thVertAlignment: CrossAxisAlignment.end,
+            thPaddingBottom: 3,
+            tdAlignment: TextAlign.left,
+            tdEditableMaxLines: 100,
+            tdPaddingTop: 0,
+            tdPaddingBottom: 14,
+            tdPaddingLeft: 10,
+            tdPaddingRight: 8,
+            focusedBorder: OutlineInputBorder(
+              borderSide: BorderSide(color: Colors.blue),
+              borderRadius: BorderRadius.all(Radius.circular(0)),
+            ),
+          ),
+        ],
       ),
       home: MyHomePage(title: 'Editable example'),
     );
@@ -144,26 +164,9 @@ class _MyHomePageState extends State<MyHomePage> {
                 onSubmitted: (value) {
                   print(value);
                 },
-                borderColor: Colors.blueGrey,
-                tdStyle: TextStyle(fontWeight: FontWeight.bold),
-                trHeight: 80,
-                thStyle: TextStyle(fontSize: 15, fontWeight: FontWeight.bold),
-                thAlignment: TextAlign.center,
-                thVertAlignment: CrossAxisAlignment.end,
-                thPaddingBottom: 3,
                 showSaveIcon: true,
                 saveIconColor: Colors.black,
                 showCreateButton: true,
-                tdAlignment: TextAlign.left,
-                tdEditableMaxLines: 100, // don't limit and allow data to wrap
-                tdPaddingTop: 0,
-                tdPaddingBottom: 14,
-                tdPaddingLeft: 10,
-                tdPaddingRight: 8,
-                focusedBorder: OutlineInputBorder(
-                  borderSide: BorderSide(color: Colors.blue),
-                  borderRadius: BorderRadius.all(Radius.circular(0)),
-                ),
               ),
             ),
           ],

--- a/lib/editable.dart
+++ b/lib/editable.dart
@@ -7,6 +7,7 @@ library editable;
 
 import 'package:flutter/material.dart';
 import 'commons/helpers.dart';
+import 'editable_theme.dart';
 import 'widgets/table_body.dart';
 import 'widgets/table_header.dart';
 
@@ -48,24 +49,24 @@ class Editable extends StatefulWidget {
       {Key? key,
       this.columns,
       this.rows,
-      this.columnRatio = 0.20,
+      this.columnRatio,
       this.onSubmitted,
       this.onRowSaved,
       this.columnCount = 0,
       this.rowCount = 0,
-      this.borderColor = Colors.grey,
-      this.tdPaddingLeft = 8.0,
-      this.tdPaddingTop = 8.0,
-      this.tdPaddingRight = 8.0,
-      this.tdPaddingBottom = 12.0,
-      this.thPaddingLeft = 8.0,
-      this.thPaddingTop = 0.0,
-      this.thPaddingRight = 8.0,
-      this.thPaddingBottom = 0.0,
-      this.trHeight = 50.0,
-      this.borderWidth = 0.5,
-      this.thWeight = FontWeight.w600,
-      this.thSize = 18,
+      this.borderColor,
+      this.tdPaddingLeft,
+      this.tdPaddingTop,
+      this.tdPaddingRight,
+      this.tdPaddingBottom,
+      this.thPaddingLeft,
+      this.thPaddingTop,
+      this.thPaddingRight,
+      this.thPaddingBottom,
+      this.trHeight,
+      this.borderWidth,
+      this.thWeight,
+      this.thSize,
       this.showSaveIcon = false,
       this.saveIcon = Icons.save,
       this.saveIconColor = Colors.black12,
@@ -86,9 +87,9 @@ class Editable extends StatefulWidget {
       this.createButtonColor,
       this.createButtonShape,
       this.createButtonLabel,
-      this.stripeColor1 = Colors.white,
-      this.stripeColor2 = Colors.black12,
-      this.zebraStripe = false,
+      this.stripeColor1,
+      this.stripeColor2,
+      this.zebraStripe,
       this.focusedBorder})
       : super(key: key);
 
@@ -150,65 +151,65 @@ class Editable extends StatefulWidget {
   /// sets the ratio of the screen width occupied by each column
   /// it is set in fraction between 0 to 1.0
   /// 0.8 indicates 80 percent width per column
-  final double columnRatio;
+  final double? columnRatio;
 
   /// Color of table border
-  final Color borderColor;
+  final Color? borderColor;
 
   /// width of table borders
-  final double borderWidth;
+  final double? borderWidth;
 
   /// Table data cell padding left
-  final double tdPaddingLeft;
+  final double? tdPaddingLeft;
 
   /// Table data cell padding top
-  final double tdPaddingTop;
+  final double? tdPaddingTop;
 
   /// Table data cell padding right
-  final double tdPaddingRight;
+  final double? tdPaddingRight;
 
   /// Table data cell padding bottom
-  final double tdPaddingBottom;
+  final double? tdPaddingBottom;
 
   /// Aligns the table data
-  final TextAlign tdAlignment;
+  final TextAlign? tdAlignment;
 
   /// Style the table data
   final TextStyle? tdStyle;
 
   /// Max lines allowed in editable text, default: 1 (longer data will not wrap and be hidden), setting to 100 will allow wrapping and not increase row size
-  final int tdEditableMaxLines;
+  final int? tdEditableMaxLines;
 
   /// Table header cell padding left
-  final double thPaddingLeft;
+  final double? thPaddingLeft;
 
   /// Table header cell padding top
-  final double thPaddingTop;
+  final double? thPaddingTop;
 
   /// Table header cell padding right
-  final double thPaddingRight;
+  final double? thPaddingRight;
 
   /// Table header cell padding bottom
-  final double thPaddingBottom;
+  final double? thPaddingBottom;
 
   /// Aligns the table header
-  final TextAlign thAlignment;
+  final TextAlign? thAlignment;
 
   /// Style the table header - use for more control of header style, using this OVERRIDES the thWeight and thSize parameters and those will be ignored.
   final TextStyle? thStyle;
 
   /// Table headers fontweight (use thStyle for more control of header style)
-  final FontWeight thWeight;
+  final FontWeight? thWeight;
 
   /// Table header label vertical alignment
-  final CrossAxisAlignment thVertAlignment;
+  final CrossAxisAlignment? thVertAlignment;
 
   /// Table headers fontSize  (use thStyle for more control of header style)
-  final double thSize;
+  final double? thSize;
 
   /// Table Row Height
   /// cannot be less than 40.0
-  final double trHeight;
+  final double? trHeight;
 
   /// Toogles the save button,
   /// if [true] displays an icon to save rows,
@@ -273,14 +274,14 @@ class Editable extends StatefulWidget {
   final Widget? createButtonLabel;
 
   /// The first row alternate color, if stripe is set to true
-  final Color stripeColor1;
+  final Color? stripeColor1;
 
   /// The Second row alternate color, if stripe is set to true
-  final Color stripeColor2;
+  final Color? stripeColor2;
 
   /// enable zebra-striping, set to false by default
   /// if enabled, you can style the colors [stripeColor1] and [stripeColor2]
-  final bool zebraStripe;
+  final bool? zebraStripe;
 
   final InputBorder? focusedBorder;
 
@@ -317,12 +318,40 @@ class EditableState extends State<Editable> {
 
   @override
   Widget build(BuildContext context) {
+    final theme = EditableTheme.of(context);
     /// initial Setup of columns and row, sets count of column and row
     rowCount = rows == null || rows!.isEmpty ? widget.rowCount : rows!.length;
     columnCount =
         columns == null || columns!.isEmpty ? columnCount : columns!.length;
     columns = columns ?? columnBlueprint(columnCount, columns);
     rows = rows ?? rowBlueprint(rowCount!, columns, rows);
+
+    final columnRatio = widget.columnRatio ?? theme.columnRatio;
+    final borderColor = widget.borderColor ?? theme.borderColor;
+    final borderWidth = widget.borderWidth ?? theme.borderWidth;
+    final tdPaddingLeft = widget.tdPaddingLeft ?? theme.tdPaddingLeft;
+    final tdPaddingTop = widget.tdPaddingTop ?? theme.tdPaddingTop;
+    final tdPaddingRight = widget.tdPaddingRight ?? theme.tdPaddingRight;
+    final tdPaddingBottom = widget.tdPaddingBottom ?? theme.tdPaddingBottom;
+    final tdAlignment = widget.tdAlignment ?? theme.tdAlignment;
+    final tdStyle = widget.tdStyle ?? theme.tdStyle;
+    final tdEditableMaxLines =
+        widget.tdEditableMaxLines ?? theme.tdEditableMaxLines;
+    final thPaddingLeft = widget.thPaddingLeft ?? theme.thPaddingLeft;
+    final thPaddingTop = widget.thPaddingTop ?? theme.thPaddingTop;
+    final thPaddingRight = widget.thPaddingRight ?? theme.thPaddingRight;
+    final thPaddingBottom = widget.thPaddingBottom ?? theme.thPaddingBottom;
+    final thAlignment = widget.thAlignment ?? theme.thAlignment;
+    final thStyle = widget.thStyle ?? theme.thStyle;
+    final thWeight = widget.thWeight ?? theme.thWeight;
+    final thVertAlignment =
+        widget.thVertAlignment ?? theme.thVertAlignment;
+    final thSize = widget.thSize ?? theme.thSize;
+    final trHeight = widget.trHeight ?? theme.trHeight;
+    final stripeColor1 = widget.stripeColor1 ?? theme.stripeColor1;
+    final stripeColor2 = widget.stripeColor2 ?? theme.stripeColor2;
+    final zebraStripe = widget.zebraStripe ?? theme.zebraStripe;
+    final focusedBorder = widget.focusedBorder ?? theme.focusedBorder;
 
     /// Builds save snd remove Icons widget
 
@@ -382,21 +411,21 @@ class EditableState extends State<Editable> {
     List<Widget> _tableHeaders() {
       return List<Widget>.generate(columnCount! + 1, (index) {
         return columnCount! + 1 == (index + 1)
-            ? iconColumn(widget.showSaveIcon, widget.thPaddingTop,
-                widget.thPaddingBottom)
+            ? iconColumn(widget.showSaveIcon, thPaddingTop,
+                thPaddingBottom)
             : THeader(
                 widthRatio: columns![index]['widthFactor'] != null
                     ? columns![index]['widthFactor'].toDouble()
-                    : widget.columnRatio,
-                thAlignment: widget.thAlignment,
-                thStyle: widget.thStyle,
-                thPaddingLeft: widget.thPaddingLeft,
-                thPaddingTop: widget.thPaddingTop,
-                thPaddingBottom: widget.thPaddingBottom,
-                thPaddingRight: widget.thPaddingRight,
+                    : columnRatio,
+                thAlignment: thAlignment,
+                thStyle: thStyle,
+                thPaddingLeft: thPaddingLeft,
+                thPaddingTop: thPaddingTop,
+                thPaddingBottom: thPaddingBottom,
+                thPaddingRight: thPaddingRight,
                 headers: columns,
-                thWeight: widget.thWeight,
-                thSize: widget.thSize,
+                thWeight: thWeight!,
+                thSize: thSize!,
                 index: index);
       });
     }
@@ -413,7 +442,7 @@ class EditableState extends State<Editable> {
             var ceditable = <bool>[];
             columns!.forEach((e) {
               ckeys.add(e['key']);
-              cwidths.add(e['widthFactor'] ?? widget.columnRatio);
+              cwidths.add(e['widthFactor'] ?? columnRatio);
               ceditable.add(e['editable'] ?? true);
             });
             var list = rows![index];
@@ -422,24 +451,24 @@ class EditableState extends State<Editable> {
                 : RowBuilder(
                     index: index,
                     col: ckeys[rowIndex],
-                    trHeight: widget.trHeight,
-                    borderColor: widget.borderColor,
-                    borderWidth: widget.borderWidth,
+                    trHeight: trHeight,
+                    borderColor: borderColor,
+                    borderWidth: borderWidth,
                     cellData: list[ckeys[rowIndex]],
-                    tdPaddingLeft: widget.tdPaddingLeft,
-                    tdPaddingTop: widget.tdPaddingTop,
-                    tdPaddingBottom: widget.tdPaddingBottom,
-                    tdPaddingRight: widget.tdPaddingRight,
-                    tdAlignment: widget.tdAlignment,
-                    tdStyle: widget.tdStyle,
-                    tdEditableMaxLines: widget.tdEditableMaxLines,
+                    tdPaddingLeft: tdPaddingLeft,
+                    tdPaddingTop: tdPaddingTop,
+                    tdPaddingBottom: tdPaddingBottom,
+                    tdPaddingRight: tdPaddingRight,
+                    tdAlignment: tdAlignment,
+                    tdStyle: tdStyle,
+                    tdEditableMaxLines: tdEditableMaxLines,
                     onSubmitted: widget.onSubmitted,
                     widthRatio: cwidths[rowIndex].toDouble(),
                     isEditable: ceditable[rowIndex],
-                    zebraStripe: widget.zebraStripe,
-                    focusedBorder: widget.focusedBorder,
-                    stripeColor1: widget.stripeColor1,
-                    stripeColor2: widget.stripeColor2,
+                    zebraStripe: zebraStripe,
+                    focusedBorder: focusedBorder,
+                    stripeColor1: stripeColor1,
+                    stripeColor2: stripeColor2,
                     onChanged: (value) {
                       ///checks if row has been edited previously
                       var result = editedRows.indexWhere((element) {
@@ -473,14 +502,14 @@ class EditableState extends State<Editable> {
             //Table Header
             createButton(),
             Container(
-              padding: EdgeInsets.only(bottom: widget.thPaddingBottom),
+              padding: EdgeInsets.only(bottom: thPaddingBottom),
               decoration: BoxDecoration(
                   border: Border(
                       bottom: BorderSide(
-                          color: widget.borderColor,
-                          width: widget.borderWidth))),
+                          color: borderColor,
+                          width: borderWidth))),
               child: Row(
-                  crossAxisAlignment: widget.thVertAlignment,
+                  crossAxisAlignment: thVertAlignment!,
                   mainAxisSize: MainAxisSize.min,
                   children: _tableHeaders()),
             ),

--- a/lib/editable_theme.dart
+++ b/lib/editable_theme.dart
@@ -1,0 +1,198 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+class EditableThemeData extends ThemeExtension<EditableThemeData> {
+  const EditableThemeData({
+    this.columnRatio = 0.20,
+    this.borderColor = Colors.grey,
+    this.borderWidth = 0.5,
+    this.tdPaddingLeft = 8.0,
+    this.tdPaddingTop = 8.0,
+    this.tdPaddingRight = 8.0,
+    this.tdPaddingBottom = 12.0,
+    this.thPaddingLeft = 8.0,
+    this.thPaddingTop = 0.0,
+    this.thPaddingRight = 8.0,
+    this.thPaddingBottom = 0.0,
+    this.trHeight = 50.0,
+    this.thWeight = FontWeight.w600,
+    this.thSize = 18,
+    this.tdAlignment = TextAlign.start,
+    this.tdStyle,
+    this.tdEditableMaxLines = 1,
+    this.thAlignment = TextAlign.start,
+    this.thStyle,
+    this.thVertAlignment = CrossAxisAlignment.center,
+    this.stripeColor1 = Colors.white,
+    this.stripeColor2 = Colors.black12,
+    this.zebraStripe = false,
+    this.focusedBorder,
+  });
+
+  final double columnRatio;
+  final Color borderColor;
+  final double borderWidth;
+  final double tdPaddingLeft;
+  final double tdPaddingTop;
+  final double tdPaddingRight;
+  final double tdPaddingBottom;
+  final TextAlign tdAlignment;
+  final TextStyle? tdStyle;
+  final int tdEditableMaxLines;
+  final double thPaddingLeft;
+  final double thPaddingTop;
+  final double thPaddingRight;
+  final double thPaddingBottom;
+  final TextAlign thAlignment;
+  final TextStyle? thStyle;
+  final FontWeight thWeight;
+  final CrossAxisAlignment thVertAlignment;
+  final double thSize;
+  final double trHeight;
+  final Color stripeColor1;
+  final Color stripeColor2;
+  final bool zebraStripe;
+  final InputBorder? focusedBorder;
+
+  EditableThemeData copyWith({
+    double? columnRatio,
+    Color? borderColor,
+    double? borderWidth,
+    double? tdPaddingLeft,
+    double? tdPaddingTop,
+    double? tdPaddingRight,
+    double? tdPaddingBottom,
+    TextAlign? tdAlignment,
+    TextStyle? tdStyle,
+    int? tdEditableMaxLines,
+    double? thPaddingLeft,
+    double? thPaddingTop,
+    double? thPaddingRight,
+    double? thPaddingBottom,
+    TextAlign? thAlignment,
+    TextStyle? thStyle,
+    FontWeight? thWeight,
+    CrossAxisAlignment? thVertAlignment,
+    double? thSize,
+    double? trHeight,
+    Color? stripeColor1,
+    Color? stripeColor2,
+    bool? zebraStripe,
+    InputBorder? focusedBorder,
+  }) {
+    return EditableThemeData(
+      columnRatio: columnRatio ?? this.columnRatio,
+      borderColor: borderColor ?? this.borderColor,
+      borderWidth: borderWidth ?? this.borderWidth,
+      tdPaddingLeft: tdPaddingLeft ?? this.tdPaddingLeft,
+      tdPaddingTop: tdPaddingTop ?? this.tdPaddingTop,
+      tdPaddingRight: tdPaddingRight ?? this.tdPaddingRight,
+      tdPaddingBottom: tdPaddingBottom ?? this.tdPaddingBottom,
+      tdAlignment: tdAlignment ?? this.tdAlignment,
+      tdStyle: tdStyle ?? this.tdStyle,
+      tdEditableMaxLines: tdEditableMaxLines ?? this.tdEditableMaxLines,
+      thPaddingLeft: thPaddingLeft ?? this.thPaddingLeft,
+      thPaddingTop: thPaddingTop ?? this.thPaddingTop,
+      thPaddingRight: thPaddingRight ?? this.thPaddingRight,
+      thPaddingBottom: thPaddingBottom ?? this.thPaddingBottom,
+      thAlignment: thAlignment ?? this.thAlignment,
+      thStyle: thStyle ?? this.thStyle,
+      thWeight: thWeight ?? this.thWeight,
+      thVertAlignment: thVertAlignment ?? this.thVertAlignment,
+      thSize: thSize ?? this.thSize,
+      trHeight: trHeight ?? this.trHeight,
+      stripeColor1: stripeColor1 ?? this.stripeColor1,
+      stripeColor2: stripeColor2 ?? this.stripeColor2,
+      zebraStripe: zebraStripe ?? this.zebraStripe,
+      focusedBorder: focusedBorder ?? this.focusedBorder,
+    );
+  }
+
+  @override
+  EditableThemeData lerp(ThemeExtension<EditableThemeData>? other, double t) {
+    if (other is! EditableThemeData) {
+      return this;
+    }
+    return EditableThemeData(
+      columnRatio: lerpDouble(columnRatio, other.columnRatio, t)!,
+      borderColor: Color.lerp(borderColor, other.borderColor, t)!,
+      borderWidth: lerpDouble(borderWidth, other.borderWidth, t)!,
+      tdPaddingLeft: lerpDouble(tdPaddingLeft, other.tdPaddingLeft, t)!,
+      tdPaddingTop: lerpDouble(tdPaddingTop, other.tdPaddingTop, t)!,
+      tdPaddingRight: lerpDouble(tdPaddingRight, other.tdPaddingRight, t)!,
+      tdPaddingBottom: lerpDouble(tdPaddingBottom, other.tdPaddingBottom, t)!,
+      tdAlignment: t < 0.5 ? tdAlignment : other.tdAlignment,
+      tdStyle: TextStyle.lerp(tdStyle, other.tdStyle, t),
+      tdEditableMaxLines: t < 0.5 ? tdEditableMaxLines : other.tdEditableMaxLines,
+      thPaddingLeft: lerpDouble(thPaddingLeft, other.thPaddingLeft, t)!,
+      thPaddingTop: lerpDouble(thPaddingTop, other.thPaddingTop, t)!,
+      thPaddingRight: lerpDouble(thPaddingRight, other.thPaddingRight, t)!,
+      thPaddingBottom: lerpDouble(thPaddingBottom, other.thPaddingBottom, t)!,
+      thAlignment: t < 0.5 ? thAlignment : other.thAlignment,
+      thStyle: TextStyle.lerp(thStyle, other.thStyle, t),
+      thWeight: t < 0.5 ? thWeight : other.thWeight,
+      thVertAlignment: t < 0.5 ? thVertAlignment : other.thVertAlignment,
+      thSize: lerpDouble(thSize, other.thSize, t)!,
+      trHeight: lerpDouble(trHeight, other.trHeight, t)!,
+      stripeColor1: Color.lerp(stripeColor1, other.stripeColor1, t)!,
+      stripeColor2: Color.lerp(stripeColor2, other.stripeColor2, t)!,
+      zebraStripe: t < 0.5 ? zebraStripe : other.zebraStripe,
+      focusedBorder: t < 0.5 ? focusedBorder : other.focusedBorder,
+    );
+  }
+
+  EditableThemeData merge(EditableThemeData? other) {
+    if (other == null) return this;
+    return copyWith(
+      columnRatio: other.columnRatio,
+      borderColor: other.borderColor,
+      borderWidth: other.borderWidth,
+      tdPaddingLeft: other.tdPaddingLeft,
+      tdPaddingTop: other.tdPaddingTop,
+      tdPaddingRight: other.tdPaddingRight,
+      tdPaddingBottom: other.tdPaddingBottom,
+      tdAlignment: other.tdAlignment,
+      tdStyle: other.tdStyle,
+      tdEditableMaxLines: other.tdEditableMaxLines,
+      thPaddingLeft: other.thPaddingLeft,
+      thPaddingTop: other.thPaddingTop,
+      thPaddingRight: other.thPaddingRight,
+      thPaddingBottom: other.thPaddingBottom,
+      thAlignment: other.thAlignment,
+      thStyle: other.thStyle,
+      thWeight: other.thWeight,
+      thVertAlignment: other.thVertAlignment,
+      thSize: other.thSize,
+      trHeight: other.trHeight,
+      stripeColor1: other.stripeColor1,
+      stripeColor2: other.stripeColor2,
+      zebraStripe: other.zebraStripe,
+      focusedBorder: other.focusedBorder,
+    );
+  }
+}
+
+class EditableTheme extends InheritedWidget {
+  const EditableTheme({Key? key, required this.data, required Widget child})
+      : super(key: key, child: child);
+
+  final EditableThemeData data;
+
+  static EditableThemeData of(BuildContext context) {
+    final theme =
+        context.dependOnInheritedWidgetOfExactType<EditableTheme>()?.data;
+    final ThemeData materialTheme = Theme.of(context);
+    final EditableThemeData defaults =
+        materialTheme.extension<EditableThemeData>() ?? const EditableThemeData();
+    return defaults.merge(theme);
+  }
+
+  @override
+  bool updateShouldNotify(EditableTheme oldWidget) => data != oldWidget.data;
+}
+
+extension EditableThemeGetter on ThemeData {
+  EditableThemeData get editableTheme =>
+      extension<EditableThemeData>() ?? const EditableThemeData();
+}

--- a/lib/widgets/table_body.dart
+++ b/lib/widgets/table_body.dart
@@ -1,55 +1,56 @@
 import 'package:flutter/material.dart';
+import '../editable_theme.dart';
 
 class RowBuilder extends StatefulWidget {
   ///Builds row elements for the table
   /// its properties are not nullable
   const RowBuilder({
     Key? key,
-    required this.tdAlignment,
-    required this.tdStyle,
-    required double trHeight,
-    required Color borderColor,
-    required double borderWidth,
+    this.tdAlignment,
+    this.tdStyle,
+    double? trHeight,
+    Color? borderColor,
+    double? borderWidth,
     required this.cellData,
     required this.index,
     required this.col,
-    required this.tdPaddingLeft,
-    required this.tdPaddingTop,
-    required this.tdPaddingBottom,
-    required this.tdPaddingRight,
-    required this.tdEditableMaxLines,
+    double? this.tdPaddingLeft,
+    double? this.tdPaddingTop,
+    double? this.tdPaddingBottom,
+    double? this.tdPaddingRight,
+    int? this.tdEditableMaxLines,
     required this.onSubmitted,
     required this.onChanged,
     required this.widthRatio,
     required this.isEditable,
-    required this.stripeColor1,
-    required this.stripeColor2,
-    required this.zebraStripe,
-    required this.focusedBorder,
+    Color? this.stripeColor1,
+    Color? this.stripeColor2,
+    bool? this.zebraStripe,
+    this.focusedBorder,
   })   : _trHeight = trHeight,
         _borderColor = borderColor,
         _borderWidth = borderWidth,
         super(key: key);
 
   /// Table row height
-  final double _trHeight;
-  final Color _borderColor;
-  final double _borderWidth;
+  final double? _trHeight;
+  final Color? _borderColor;
+  final double? _borderWidth;
   final cellData;
   final double? widthRatio;
   final bool isEditable;
-  final TextAlign tdAlignment;
+  final TextAlign? tdAlignment;
   final TextStyle? tdStyle;
   final int index;
   final col;
-  final double tdPaddingLeft;
-  final double tdPaddingTop;
-  final double tdPaddingBottom;
-  final double tdPaddingRight;
-  final int tdEditableMaxLines;
-  final Color stripeColor1;
-  final Color stripeColor2;
-  final bool zebraStripe;
+  final double? tdPaddingLeft;
+  final double? tdPaddingTop;
+  final double? tdPaddingBottom;
+  final double? tdPaddingRight;
+  final int? tdEditableMaxLines;
+  final Color? stripeColor1;
+  final Color? stripeColor2;
+  final bool? zebraStripe;
   final InputBorder? focusedBorder;
   final ValueChanged<String>? onSubmitted;
   final ValueChanged<String> onChanged;
@@ -61,65 +62,80 @@ class RowBuilder extends StatefulWidget {
 class _RowBuilderState extends State<RowBuilder> {
   @override
   Widget build(BuildContext context) {
+    final theme = EditableTheme.of(context);
     double width = MediaQuery.of(context).size.width;
+    final trHeight = widget._trHeight ?? theme.trHeight;
+    final borderColor = widget._borderColor ?? theme.borderColor;
+    final borderWidth = widget._borderWidth ?? theme.borderWidth;
+    final tdAlignment = widget.tdAlignment ?? theme.tdAlignment;
+    final tdStyle = widget.tdStyle ?? theme.tdStyle;
+    final tdPaddingLeft = widget.tdPaddingLeft ?? theme.tdPaddingLeft;
+    final tdPaddingTop = widget.tdPaddingTop ?? theme.tdPaddingTop;
+    final tdPaddingRight = widget.tdPaddingRight ?? theme.tdPaddingRight;
+    final tdPaddingBottom = widget.tdPaddingBottom ?? theme.tdPaddingBottom;
+    final tdEditableMaxLines =
+        widget.tdEditableMaxLines ?? theme.tdEditableMaxLines;
+    final stripeColor1 = widget.stripeColor1 ?? theme.stripeColor1;
+    final stripeColor2 = widget.stripeColor2 ?? theme.stripeColor2;
+    final zebraStripe = widget.zebraStripe ?? theme.zebraStripe;
+    final focusedBorder = widget.focusedBorder ?? theme.focusedBorder;
     return Flexible(
       fit: FlexFit.loose,
       flex: 6,
       child: Container(
-        height: widget._trHeight < 40 ? 40 : widget._trHeight,
+        height: trHeight < 40 ? 40 : trHeight,
         width: width * widget.widthRatio!,
         decoration: BoxDecoration(
-            color: !widget.zebraStripe
+            color: !zebraStripe
                 ? null
                 : (widget.index % 2 == 1.0
-                    ? widget.stripeColor2
-                    : widget.stripeColor1),
+                    ? stripeColor2
+                    : stripeColor1),
             border: Border.all(
-                color: widget._borderColor, width: widget._borderWidth)),
+                color: borderColor, width: borderWidth)),
         child: widget.isEditable
             ? TextFormField(
-                textAlign: widget.tdAlignment,
-                style: widget.tdStyle,
+                textAlign: tdAlignment,
+                style: tdStyle,
                 initialValue: widget.cellData.toString(),
                 onFieldSubmitted: widget.onSubmitted,
                 onChanged: widget.onChanged,
                 textAlignVertical: TextAlignVertical.center,
-                maxLines: widget.tdEditableMaxLines,
+                maxLines: tdEditableMaxLines,
                 decoration: InputDecoration(
-                  filled: widget.zebraStripe,
+                  filled: zebraStripe,
                   fillColor: widget.index % 2 == 1.0
-                      ? widget.stripeColor2
-                      : widget.stripeColor1,
+                      ? stripeColor2
+                      : stripeColor1,
                   contentPadding: EdgeInsets.only(
-                      left: widget.tdPaddingLeft,
-                      right: widget.tdPaddingRight,
-                      top: widget.tdPaddingTop,
-                      bottom: widget.tdPaddingBottom),
+                      left: tdPaddingLeft,
+                      right: tdPaddingRight,
+                      top: tdPaddingTop,
+                      bottom: tdPaddingBottom),
                   border: InputBorder.none,
-                  focusedBorder: widget.focusedBorder,
+                  focusedBorder: focusedBorder,
                 ),
               )
             : Container(
                 alignment: Alignment.centerLeft,
                 padding: EdgeInsets.only(
-                  left: widget.tdPaddingLeft,
-                  right: widget.tdPaddingRight,
-                  // top: widget.tdPaddingTop,
-                  // bottom: widget.tdPaddingBottom,
+                  left: tdPaddingLeft,
+                  right: tdPaddingRight,
+                  // top: tdPaddingTop,
+                  // bottom: tdPaddingBottom,
                 ),
                 decoration: BoxDecoration(
-                  color: !widget.zebraStripe
+                  color: !zebraStripe
                       ? null
                       : (widget.index % 2 == 1.0
-                          ? widget.stripeColor2
-                          : widget.stripeColor1),
+                          ? stripeColor2
+                          : stripeColor1),
                 ),
                 child: Text(
                   widget.cellData.toString(),
-                  textAlign: widget.tdAlignment,
-                  style: widget.tdStyle ??
+                  textAlign: tdAlignment,
+                  style: tdStyle ??
                       TextStyle(
-                          // fontSize: Theme.of(context).textTheme.bodyText1.fontSize), // returns 14?
                           fontSize: 16),
                 ),
               ),

--- a/lib/widgets/table_header.dart
+++ b/lib/widgets/table_header.dart
@@ -1,18 +1,19 @@
 import 'package:flutter/material.dart';
+import '../editable_theme.dart';
 
 class THeader extends StatelessWidget {
   ///Builds elements for the table headers
   const THeader(
       {Key? key,
-      required this.thPaddingLeft,
-      required this.thPaddingTop,
-      required this.thPaddingBottom,
-      required this.thPaddingRight,
+      this.thPaddingLeft,
+      this.thPaddingTop,
+      this.thPaddingBottom,
+      this.thPaddingRight,
       required List? headers,
-      required this.thAlignment,
-      required this.thStyle,
-      required FontWeight thWeight,
-      required double thSize,
+      this.thAlignment,
+      this.thStyle,
+      FontWeight? thWeight,
+      double? thSize,
       required double? widthRatio,
       required int index})
       : _headers = headers,
@@ -22,37 +23,46 @@ class THeader extends StatelessWidget {
         _widthRatio = widthRatio,
         super(key: key);
 
-  final double thPaddingLeft;
-  final double thPaddingTop;
-  final double thPaddingBottom;
-  final double thPaddingRight;
+  final double? thPaddingLeft;
+  final double? thPaddingTop;
+  final double? thPaddingBottom;
+  final double? thPaddingRight;
   final List? _headers;
   final TextAlign? thAlignment;
   final TextStyle? thStyle;
-  final FontWeight _thWeight;
-  final double _thSize;
+  final FontWeight? _thWeight;
+  final double? _thSize;
   final int _index;
   final double? _widthRatio;
   @override
   Widget build(BuildContext context) {
+    final theme = EditableTheme.of(context);
     double width = MediaQuery.of(context).size.width;
+    final paddingLeft = thPaddingLeft ?? theme.thPaddingLeft;
+    final paddingTop = thPaddingTop ?? theme.thPaddingTop;
+    final paddingBottom = thPaddingBottom ?? theme.thPaddingBottom;
+    final paddingRight = thPaddingRight ?? theme.thPaddingRight;
+    final textAlign = thAlignment ?? theme.thAlignment;
+    final style = thStyle ??
+        TextStyle(
+            fontWeight: _thWeight ?? theme.thWeight,
+            fontSize: _thSize ?? theme.thSize);
     return Flexible(
       fit: FlexFit.loose,
       child: Container(
         width: width * _widthRatio!,
         child: Padding(
           padding: EdgeInsets.only(
-              left: thPaddingLeft,
-              top: thPaddingTop,
-              bottom: thPaddingBottom,
-              right: thPaddingRight),
+              left: paddingLeft,
+              top: paddingTop,
+              bottom: paddingBottom,
+              right: paddingRight),
           child: Text(
             _headers != null || _headers!.isNotEmpty
                 ? _headers![_index]['title']
                 : '',
-            style:
-                thStyle ?? TextStyle(fontWeight: _thWeight, fontSize: _thSize),
-            textAlign: thAlignment ?? TextAlign.start,
+            style: style,
+            textAlign: textAlign,
           ),
         ),
       ),


### PR DESCRIPTION
## Summary
- create `EditableThemeData` and `EditableTheme`
- read default styles from the theme when widget values are null
- update example to configure the theme via `ThemeData.extensions`
- document using the theme

## Testing
- `flutter test ./test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685f9f4bd468832a9d18d0ce77a0429f